### PR TITLE
Fix bug in `acc2gtdb_tax.py`

### DIFF
--- a/bin/acc2gtdb_tax.py
+++ b/bin/acc2gtdb_tax.py
@@ -91,7 +91,7 @@ def seq_acc2tax(genome_file, genome_acc2taxid, seq_acc2taxid):
     acc_code = {"GCF": "RS_", "GCA": "GB_"}
     print(genome_file)
     splitpath = genome_file.split("/")
-    acc_prefix = acc_code[splitpath[-4]]
+    acc_prefix = acc_code[splitpath[-5]]
     splitname = splitpath[-1].split("_")
     genome_acc = f"{acc_prefix}{splitname[0]}_{splitname[1]}"
     with gzip.open(genome_file, "rb") as f:


### PR DESCRIPTION
Fixes [issue#17](https://github.com/nick-youngblut/gtdb_to_taxdump/issues/17).
The genomes in the database directory in `gtdbtk_<versionNumber>_data.tar.gz` as well as in the representative genome directory ([gtdb_genomes_reps_r207.tar.gz](https://data.gtdb.ecogenomic.org/releases/release207/207.0/genomic_files_reps/gtdb_genomes_reps_r207.tar.gz)) are in the form `/database/GCA/001/508/855/<genome>.fna.gz`. The `seq_acc2tax` [function](https://github.com/nick-youngblut/gtdb_to_taxdump/blob/4cb725d572e717b70c0f21340dac0f9bf1aa31f8/bin/acc2gtdb_tax.py#L83) in `acc2gtdb_tax.py` groups genomes into GCA or GCF by grabbing the string from the genome path. However, currently, it's splitting the string by `/` and then grabbing the fourth element from the end ([link](https://github.com/nick-youngblut/gtdb_to_taxdump/blob/4cb725d572e717b70c0f21340dac0f9bf1aa31f8/bin/acc2gtdb_tax.py#L91-L94)). This is incorrect as it grabs the number before GCA or GCF and not GCA or GCF itself. 
This PR fixes that by grabbing the fifth element from reverse after splitting. 